### PR TITLE
Add Array support to Configurator

### DIFF
--- a/latte/src/main/java/gg/beemo/latte/config/annotations/ConfiguratorArray.java
+++ b/latte/src/main/java/gg/beemo/latte/config/annotations/ConfiguratorArray.java
@@ -1,0 +1,25 @@
+package gg.beemo.latte.config.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Tells {@link  gg.beemo.latte.config.Configurator} that this field is an array. The individual entries
+ * in the input string are delimited by the specified delimiter. If this annotation is not present, and
+ * the field is an Array type, a default delimiter of "," is assumed. If this annotation is used on a field
+ * that is not an Array type, the Configurator will exit with an error.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ConfiguratorArray {
+
+    /**
+     * The delimiter to use to split the input string into multiple entries. Defaults to ",".
+     *
+     * @return The delimiter to use.
+     */
+    String delimiter() default ",";
+
+}

--- a/vanilla/src/main/java/gg/beemo/vanilla/Config.java
+++ b/vanilla/src/main/java/gg/beemo/vanilla/Config.java
@@ -2,6 +2,6 @@ package gg.beemo.vanilla;
 
 public class Config {
 
-    public static String KAFKA_HOST = "localhost:9092";
+    public static String[] KAFKA_HOST = new String[]{"localhost:9092"};
 
 }

--- a/vanilla/src/main/java/gg/beemo/vanilla/Vanilla.java
+++ b/vanilla/src/main/java/gg/beemo/vanilla/Vanilla.java
@@ -17,7 +17,7 @@ public class Vanilla {
         try {
             LOGGER.debug("Initializing Kafka connection");
             KafkaConnection kafkaConnection = new KafkaConnection(
-                    Config.KAFKA_HOST,
+                    String.join(",", Config.KAFKA_HOST),
                     "vanilla",
                     "vanilla",
                     CommonConfig.VANILLA_CLUSTER_ID


### PR DESCRIPTION
This adds support for parsing Array types to the Latte Configurator. It will automatically detect when a field is an Array type, and dynamically parse the environment values into an array of the proper type. By default, array entries are delimited with a `,` in the input string; this can be overridden on a per-field basis using the optional `@ConfiguratorArray(delimiter = ",")` annotation.

This will be useful in the future for configuring things like multi-node Kafka hosts; for a connection, multiple hosts can be specified for redundancy, and the application will choose a random of these hosts to connect to. The config field can be specified as normal, just using an Array type and the proper default value.

```
public static String[] TEA_KAFKA_HOST = new String[]{"localhost:9092"};
```

Vanilla has also been updated to use this new feature. Note that while at the moment, Vanilla just joins the Kafka hosts Array back together into a single string, in a future rework of the Broker code, the hosts argument will be changed to an Array, removing the need for this implementation quirk (and requiring a parsed Array as the argument).