### PR TITLE
[latte] Fix BrokerClient topic handling

### DIFF
--- a/latte/src/main/java/gg/beemo/latte/broker/BrokerConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/BrokerConnection.kt
@@ -21,6 +21,7 @@ abstract class BrokerConnection {
 
     abstract suspend fun start()
     open fun destroy() {
+        log.debug("Destroying BrokerConnection")
         topicListeners.clear()
     }
 

--- a/latte/src/main/java/gg/beemo/latte/broker/kafka/KafkaConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/kafka/KafkaConnection.kt
@@ -91,6 +91,7 @@ class KafkaConnection(
     }
 
     override fun destroy() {
+        log.debug("Destroying KafkaConnection")
         consumer?.close()
         consumer = null
         producer?.close()

--- a/latte/src/main/java/gg/beemo/latte/broker/rpc/RpcClient.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/rpc/RpcClient.kt
@@ -158,7 +158,7 @@ class RpcClient<RequestT, ResponseT>(
 
     }
 
-    override fun destroy() {
+    override fun doDestroy() {
         requestProducer.destroy()
         requestConsumer.destroy()
     }

--- a/latte/src/main/resources/log4j2.xml
+++ b/latte/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level}{FATAL=bg_bright_red, ERROR=bright_red, WARN=bright_yellow, INFO=bright_green, DEBUG=bright_cyan, TRACE=bright_white} [%style{%t}{bright_white}] %style{%logger{36}}{white}: %msg%n%ex</Property>
     </Properties>

--- a/vanilla/src/main/java/gg/beemo/vanilla/Vanilla.kt
+++ b/vanilla/src/main/java/gg/beemo/vanilla/Vanilla.kt
@@ -4,7 +4,9 @@ import gg.beemo.latte.CommonConfig
 import gg.beemo.latte.broker.kafka.KafkaConnection
 import gg.beemo.latte.config.Configurator
 import gg.beemo.latte.logging.Log
+import gg.beemo.latte.logging.log
 import kotlinx.coroutines.runBlocking
+import org.apache.logging.log4j.LogManager
 
 object Vanilla {
 
@@ -25,7 +27,14 @@ object Vanilla {
         )
 
         log.debug("Initializing Kafka Ratelimit client")
-        RatelimitClient(brokerConnection)
+        val ratelimitClient = RatelimitClient(brokerConnection)
+
+        Runtime.getRuntime().addShutdownHook(Thread({
+            log.info("Destroying everything")
+            ratelimitClient.destroy()
+            brokerConnection.destroy()
+            LogManager.shutdown(true, true)
+        }, "Vanilla Shutdown Hook"))
 
         log.debug("Starting Kafka connection")
         brokerConnection.start()


### PR DESCRIPTION
There was a bug in the previous implementation where the BrokerClient would deregister a topic as soon as a specific _key_ didn't have any listeners, ignoring the fact that other keys might be listening on the same topic. In tea this caused errors, because our clients then tried to access topics that were errorneously removed. This PR fixes the logic to only deregister a topic when there actually are no listeners for _any_ keys. It also moves this handling of keys and topics into the `TopicMetadata` class so that the `BrokerClient` doesn't have to deal with it anymore.

Additionally, a bug/error caused by recursive BrokerClient destruction has been fixed, and some additional logging added. The Log4j config has been adjusted to actually allow those logs to be processed; previously, Log4j would use its own shutdown hook and stop logging anything once shutdown is initiated, meaning we didn't see the aforementioned errors and logs during destruction.