### PR TITLE
Add RabbitConnection for RabbitMQ

### DIFF
--- a/latte/build.gradle.kts
+++ b/latte/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
     implementation("org.apache.kafka:kafka-streams:$kafkaVersion")
 
+    // RabbitMQ
+    val rabbitVersion = "5.20.0"
+    implementation("com.rabbitmq:amqp-client:$rabbitVersion")
+
     // JSON
     val moshiVersion = "1.14.0"
     implementation("com.squareup.moshi:moshi:$moshiVersion")

--- a/latte/src/main/java/gg/beemo/latte/broker/LocalConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/LocalConnection.kt
@@ -6,6 +6,7 @@ class LocalConnection(
 ) : BrokerConnection() {
 
     override val supportsTopicHotSwap = true
+    override val deferInitialTopicCreation = false
 
     override suspend fun abstractSend(
         topic: String,
@@ -30,7 +31,7 @@ class LocalConnection(
         return headers.messageId
     }
 
-    override suspend fun start() {
+    override suspend fun abstractStart() {
         // Nothing to start :)
     }
 

--- a/latte/src/main/java/gg/beemo/latte/broker/kafka/KafkaConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/kafka/KafkaConnection.kt
@@ -36,6 +36,7 @@ class KafkaConnection(
 ) : BrokerConnection() {
 
     override val supportsTopicHotSwap = false
+    override val deferInitialTopicCreation = false
     private val kafkaHostsString = kafkaHosts.joinToString(",")
     private val log by Log
 
@@ -81,7 +82,7 @@ class KafkaConnection(
         return headers.messageId
     }
 
-    override suspend fun start() {
+    override suspend fun abstractStart() {
         check(!isRunning) { "KafkaConnection is already running!" }
         log.debug("Starting Kafka Connection")
         createTopics()

--- a/latte/src/main/java/gg/beemo/latte/broker/rabbitmq/RabbitConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/rabbitmq/RabbitConnection.kt
@@ -1,0 +1,70 @@
+package gg.beemo.latte.broker.rabbitmq
+
+import com.rabbitmq.client.Address
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import gg.beemo.latte.broker.BrokerConnection
+import gg.beemo.latte.broker.BrokerMessageHeaders
+import gg.beemo.latte.broker.MessageId
+import gg.beemo.latte.logging.Log
+import java.util.Collections
+
+// TODO Implementation considerations:
+//  - Channels are not thread-safe (for sending); need to create a coroutine-wrapper around them
+//  - "Consuming in one thread and publishing in another thread on a shared channel can be safe."
+
+class RabbitConnection(
+    rabbitHosts: Array<String>,
+    override val serviceName: String,
+    override val instanceId: String,
+    private val useTls: Boolean = false,
+) : BrokerConnection() {
+
+    override val supportsTopicHotSwap = true
+    private val rabbitAddresses = rabbitHosts.map(Address::parseAddress)
+    private val log by Log
+
+    private var connection: Connection? = null
+    private val channels = Collections.synchronizedMap(HashMap<String, Channel>())
+
+    override suspend fun start() {
+        connection = ConnectionFactory().apply {
+            if (useTls) {
+                // TODO This will trust every cert, even self-signed ones
+                useSslProtocol()
+            }
+        }.newConnection(rabbitAddresses, instanceId)
+        // TODO Create exchange
+    }
+
+    override suspend fun abstractSend(
+        topic: String,
+        key: String,
+        value: String,
+        headers: BrokerMessageHeaders
+    ): MessageId {
+        TODO()
+    }
+
+    override fun destroy() {
+        log.debug("Destroying RabbitConnection")
+        connection?.close()
+        connection = null
+        super.destroy()
+    }
+
+    override fun createTopic(topic: String) {
+        val channel = channels.computeIfAbsent(topic) {
+            val connection = checkNotNull(connection) { "Connection not open" }
+            connection.createChannel()
+        }
+        // TODO Consume
+    }
+
+    override fun removeTopic(topic: String) {
+        val channel = channels.remove(topic)
+        channel?.close()
+    }
+
+}

--- a/latte/src/main/java/gg/beemo/latte/broker/rabbitmq/RabbitConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/rabbitmq/RabbitConnection.kt
@@ -18,9 +18,6 @@ private class ChannelData(
     var consumerTag: String? = null,
 )
 
-// TODO Temporary keys/topics created by RPC clients should ideally be cached and re-used,
-//  instead of being destroyed and recreated every time.
-
 class RabbitConnection(
     rabbitHosts: Array<String>,
     override val serviceName: String,

--- a/latte/src/main/java/gg/beemo/latte/ratelimit/SharedRatelimitData.kt
+++ b/latte/src/main/java/gg/beemo/latte/ratelimit/SharedRatelimitData.kt
@@ -18,7 +18,7 @@ object SharedRatelimitData {
 
     enum class RatelimitType {
         @Json(name = "global")
-        GLBOAL,
+        GLOBAL,
 
         @Json(name = "identify")
         IDENTIFY,

--- a/latte/src/test/kotlin/gg/beemo/latte/broker/TestBrokerClient.kt
+++ b/latte/src/test/kotlin/gg/beemo/latte/broker/TestBrokerClient.kt
@@ -22,7 +22,7 @@ class TestBrokerClient(
 
     val greetingRpc = rpc<GreetingRequest, GreetingResponse>(
         topic = "rpc.greetings",
-        key = "greeting.requests",
+        key = "greet",
     ) {
         log.info("greetingRpc received request: ${it.value}")
         return@rpc RpcStatus.OK to GreetingResponse("Hello, ${it.value.name}")

--- a/vanilla/src/main/java/gg/beemo/vanilla/KafkaRatelimitClient.kt
+++ b/vanilla/src/main/java/gg/beemo/vanilla/KafkaRatelimitClient.kt
@@ -39,7 +39,7 @@ class RatelimitClient(connection: BrokerConnection) : BrokerClient(connection) {
 
             log.debug("Incoming {} quota request from service {}", type, service)
             val provider = when (msg.type) {
-                SharedRatelimitData.RatelimitType.GLBOAL -> globalRatelimitProvider
+                SharedRatelimitData.RatelimitType.GLOBAL -> globalRatelimitProvider
                 SharedRatelimitData.RatelimitType.IDENTIFY -> identifyRatelimitProvider
                 else -> throw IllegalArgumentException("Unknown ratelimit type ${msg.type}")
             }


### PR DESCRIPTION
Add support for RabbitMQ, cause we are fed up with how complex Kafka is to maintain.

While RabbitMQ allows dynamically creating and removing topics (since technically it doesn't even work on "topics", it uses queues, exchanges and routing keys), to avoid doing so on every RPC request, the RPC client has been updated to always keep the response producer/consumer around.