### PR TITLE
[Latte] Add `tryRequestQuota` for `SuspendingRatelimit`

### DIFF
--- a/latte/src/main/java/gg/beemo/latte/util/SuspendingRatelimit.kt
+++ b/latte/src/main/java/gg/beemo/latte/util/SuspendingRatelimit.kt
@@ -46,16 +46,15 @@ class SuspendingRatelimit(private val burst: Int, private val duration: Duration
         }
     }
 
-    suspend fun tryRequestQuota(): Pair<Boolean, Long?> =
-        quotaRequestSem.withPermit {
-            if (remainingQuota <= 0) {
-                val waitTime = calculateWaitTime()
-                return@withPermit false to waitTime
-            }
-            tryResetQuota()
-
-            check(remainingQuota > 0)
-            remainingQuota--
-            return@withPermit true to null
+    fun tryRequestQuota(): Pair<Boolean, Long?>  {
+        if (remainingQuota <= 0) {
+            val waitTime = calculateWaitTime()
+            return false to waitTime
         }
+        tryResetQuota()
+
+        check(remainingQuota > 0)
+        remainingQuota--
+        return true to null
+    }
 }

--- a/latte/src/main/java/gg/beemo/latte/util/SuspendingRatelimit.kt
+++ b/latte/src/main/java/gg/beemo/latte/util/SuspendingRatelimit.kt
@@ -6,32 +6,56 @@ import kotlinx.coroutines.sync.withPermit
 import kotlin.time.Duration
 
 class SuspendingRatelimit(private val burst: Int, private val duration: Duration) {
-
     @Volatile
     private var remainingQuota: Int = burst
+
     @Volatile
     private var resetTimestamp: Long = 0
 
     private val quotaRequestSem = Semaphore(1)
 
-    fun overrideRatelimit(remainingQuota: Int, resetTimestamp: Long) {
+    fun overrideRatelimit(
+        remainingQuota: Int,
+        resetTimestamp: Long,
+    ) {
         this.remainingQuota = remainingQuota
         this.resetTimestamp = resetTimestamp
+    }
+
+    private fun calculateWaitTime(): Long {
+        return (resetTimestamp - System.currentTimeMillis()).coerceAtLeast(0)
+    }
+
+    private fun tryResetQuota() {
+        if (System.currentTimeMillis() >= resetTimestamp) {
+            remainingQuota = burst
+            resetTimestamp = System.currentTimeMillis() + duration.inWholeMilliseconds
+        }
     }
 
     suspend fun requestQuota() {
         quotaRequestSem.withPermit {
             if (remainingQuota <= 0) {
-                val waitTime = (resetTimestamp - System.currentTimeMillis()).coerceAtLeast(0)
+                val waitTime = calculateWaitTime()
                 delay(waitTime)
             }
-            if (System.currentTimeMillis() >= resetTimestamp) {
-                remainingQuota = burst
-                resetTimestamp = System.currentTimeMillis() + duration.inWholeMilliseconds
-            }
+            tryResetQuota()
+
             check(remainingQuota > 0)
             remainingQuota--
         }
     }
 
+    suspend fun tryRequestQuota(): Pair<Boolean, Long?> =
+        quotaRequestSem.withPermit {
+            if (remainingQuota <= 0) {
+                val waitTime = calculateWaitTime()
+                return@withPermit false to waitTime
+            }
+            tryResetQuota()
+
+            check(remainingQuota > 0)
+            remainingQuota--
+            return@withPermit true to null
+        }
 }


### PR DESCRIPTION
This pull request adds `tryRequestQuota` for  `SuspendingRatelimit` to enable a wider range of applications, such as rate-limiting specific commands.  Unlike `requestQuota`, `tryRequestQuota` doesn't wait for the quota to be available, but instead, returns a pair of a Boolean (`canProceed`) and a nullable Long (`remainingWaitTime`) which can be useful for such applications.

- [x] This pull request has been tested to work.