### PR TITLE
Catch errors parsing broker message headers

### DIFF
--- a/latte/src/main/java/gg/beemo/latte/broker/rabbitmq/RabbitConnection.kt
+++ b/latte/src/main/java/gg/beemo/latte/broker/rabbitmq/RabbitConnection.kt
@@ -96,9 +96,13 @@ class RabbitConnection(
                 body: ByteArray
             ) {
                 val key = envelope.routingKey ?: ""
-                val value = String(body)
-                val headers = BrokerMessageHeaders(properties.headers.mapValues { it.value.toString() })
-                dispatchIncomingMessage(topic, key, value, headers)
+                try {
+                    val value = String(body)
+                    val headers = BrokerMessageHeaders(properties.headers.mapValues { it.value.toString() })
+                    dispatchIncomingMessage(topic, key, value, headers)
+                } catch (e: Exception) {
+                    log.error("Error handling incoming broker message in topic $topic, dropping message", e)
+                }
                 channel.basicAck(envelope.deliveryTag, false)
             }
 


### PR DESCRIPTION
There was no error handling for parsing headers of incoming broker messages. Not sure what happens with ungaught errors in the RabbitMQ library, but the Kafka library would be really angry at once, so let's make sure nothing will be angry at us if there is incoming malformed data :)